### PR TITLE
adding boost/bind/bind.hpp includes to files missing them and replacing <boost/bind.hpp> with <boost/bind/bind.hpp>

### DIFF
--- a/clients/roscpp/include/ros/node_handle.h
+++ b/clients/roscpp/include/ros/node_handle.h
@@ -47,7 +47,7 @@
 #include "ros/init.h"
 #include "common.h"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <xmlrpcpp/XmlRpcValue.h>
 

--- a/clients/roscpp/include/ros/publisher.h
+++ b/clients/roscpp/include/ros/publisher.h
@@ -32,7 +32,7 @@
 #include "ros/common.h"
 #include "ros/message.h"
 #include "ros/serialization.h"
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/thread/mutex.hpp>
 
 namespace ros

--- a/clients/roscpp/include/ros/timer_manager.h
+++ b/clients/roscpp/include/ros/timer_manager.h
@@ -40,6 +40,8 @@
 #include "ros/assert.h"
 #include "ros/callback_queue_interface.h"
 
+#include <boost/bind/bind.hpp>
+
 #include <vector>
 #include <list>
 

--- a/clients/roscpp/include/ros/topic_manager.h
+++ b/clients/roscpp/include/ros/topic_manager.h
@@ -35,6 +35,7 @@
 
 #include "xmlrpcpp/XmlRpcValue.h"
 
+#include <boost/bind/bind.hpp>
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/recursive_mutex.hpp>
 

--- a/clients/roscpp/src/libros/connection.cpp
+++ b/clients/roscpp/src/libros/connection.cpp
@@ -39,7 +39,7 @@
 #include <ros/assert.h>
 
 #include <boost/shared_array.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 namespace ros
 {

--- a/clients/roscpp/src/libros/connection_manager.cpp
+++ b/clients/roscpp/src/libros/connection_manager.cpp
@@ -35,6 +35,7 @@
 #include "ros/file_log.h"
 #include "ros/network.h"
 
+#include <boost/bind/bind.hpp>
 #include <ros/assert.h>
 
 namespace ros

--- a/clients/roscpp/src/libros/intraprocess_publisher_link.cpp
+++ b/clients/roscpp/src/libros/intraprocess_publisher_link.cpp
@@ -42,7 +42,7 @@
 #include "ros/connection_manager.h"
 #include "ros/file_log.h"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <sstream>
 

--- a/clients/roscpp/src/libros/intraprocess_subscriber_link.cpp
+++ b/clients/roscpp/src/libros/intraprocess_subscriber_link.cpp
@@ -37,7 +37,7 @@
 #include "ros/topic_manager.h"
 #include "ros/file_log.h"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 namespace ros
 {

--- a/clients/roscpp/src/libros/poll_set.cpp
+++ b/clients/roscpp/src/libros/poll_set.cpp
@@ -39,7 +39,7 @@
 
 #include <ros/assert.h>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <fcntl.h>
 

--- a/clients/roscpp/src/libros/publisher_link.cpp
+++ b/clients/roscpp/src/libros/publisher_link.cpp
@@ -41,7 +41,7 @@
 #include "ros/connection_manager.h"
 #include "ros/file_log.h"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <sstream>
 

--- a/clients/roscpp/src/libros/service_client_link.cpp
+++ b/clients/roscpp/src/libros/service_client_link.cpp
@@ -41,7 +41,7 @@
 #include "ros/this_node.h"
 #include "ros/file_log.h"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 namespace ros
 {

--- a/clients/roscpp/src/libros/service_publication.cpp
+++ b/clients/roscpp/src/libros/service_publication.cpp
@@ -37,7 +37,7 @@
 #include "ros/connection.h"
 #include "ros/callback_queue_interface.h"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <std_msgs/String.h>
 

--- a/clients/roscpp/src/libros/service_server_link.cpp
+++ b/clients/roscpp/src/libros/service_server_link.cpp
@@ -40,7 +40,7 @@
 #include "ros/this_node.h"
 #include "ros/file_log.h"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <sstream>
 

--- a/clients/roscpp/src/libros/subscriber_link.cpp
+++ b/clients/roscpp/src/libros/subscriber_link.cpp
@@ -28,7 +28,7 @@
 #include "ros/subscriber_link.h"
 #include "ros/publication.h"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 namespace ros
 {

--- a/clients/roscpp/src/libros/topic_manager.cpp
+++ b/clients/roscpp/src/libros/topic_manager.cpp
@@ -43,6 +43,7 @@
 
 #include "xmlrpcpp/XmlRpc.h"
 
+#include <boost/bind/bind.hpp>
 #include <ros/console.h>
 
 using namespace XmlRpc; // A battle to be fought later

--- a/clients/roscpp/src/libros/transport/transport_tcp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_tcp.cpp
@@ -39,7 +39,7 @@
 #include "ros/file_log.h"
 #include <ros/assert.h>
 #include <sstream>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <fcntl.h>
 #include <errno.h>
 #ifndef _WIN32

--- a/clients/roscpp/src/libros/transport/transport_udp.cpp
+++ b/clients/roscpp/src/libros/transport/transport_udp.cpp
@@ -37,7 +37,7 @@
 #include "ros/file_log.h"
 
 #include <ros/assert.h>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #ifndef _WIN32
   #include <sys/socket.h>  // explicit include required for FreeBSD
 #endif

--- a/clients/roscpp/src/libros/transport_publisher_link.cpp
+++ b/clients/roscpp/src/libros/transport_publisher_link.cpp
@@ -48,7 +48,7 @@
 #include "ros/callback_queue.h"
 #include "ros/internal_timer_manager.h"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 #include <sstream>
 

--- a/clients/roscpp/src/libros/transport_subscriber_link.cpp
+++ b/clients/roscpp/src/libros/transport_subscriber_link.cpp
@@ -36,7 +36,7 @@
 #include "ros/topic_manager.h"
 #include "ros/file_log.h"
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 
 namespace ros
 {


### PR DESCRIPTION
I was getting many of these warning messages until I made these changes, building on Ubuntu 24.04:

```
In file included from /usr/include/boost/smart_ptr/detail/requires_cxx11.hpp:9,
                 from /usr/include/boost/smart_ptr/shared_ptr.hpp:17,
                 from /usr/include/boost/shared_ptr.hpp:17,
                 from /home/lucasw/ros/ros1/install/underlay_ws/src/ros_comm/clients/roscpp/include/ros/forwards.h:37,
                 from /home/lucasw/ros/ros1/install/underlay_ws/devel/.private/roscpp/include/ros/common.h:37,
                 from /home/lucasw/ros/ros1/install/underlay_ws/src/ros_comm/clients/roscpp/include/ros/subscriber_link.h:31,
                 from /home/lucasw/ros/ros1/install/underlay_ws/src/ros_comm/clients/roscpp/include/ros/intraprocess_subscriber_link.h:30,
                 from /home/lucasw/ros/ros1/install/underlay_ws/src/ros_comm/clients/roscpp/src/libros/intraprocess_subscriber_link.cpp:29:
/usr/include/boost/bind.hpp:36:1: note: ‘#pragma message: The practice of declaring the Bind placeholders (_1, _2, ...) in the global namespace is deprecated. Please use <boost/bind/bind.hpp> + using namespace boost::placeholders, or define BOOST_BIND_GLOBAL_PLACEHOLDERS to retain the current behavior.’
   36 | BOOST_PRAGMA_MESSAGE(
      | ^~~~~~~~~~~~~~~~~~~~
```